### PR TITLE
Improvement of waits for motion

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,8 +1,7 @@
 # Adam's Concert-EPICS interface
 import os
 
-from edc.shutter import CLSShutter
-from edc.motor import CLSLinear, ABRS, SimMotor
+
 # PyQT imports
 from PyQt5.QtWidgets import QGroupBox, QDialog, QApplication, QGridLayout
 from PyQt5.QtWidgets import QLabel, QPushButton, QDoubleSpinBox
@@ -22,6 +21,7 @@ from on_the_fly_reco_settings import RecoSettingsGroup
 # Concert imports
 from concert.storage import DirectoryWalker
 from concert.ext.viewers import PyplotImageViewer
+from concert.devices.shutters.dummy import Shutter as DummyShutter
 from concert.experiments.imaging import (tomo_projections_number, tomo_max_speed, frames)
 from concert.base import TransitionNotAllowed
 # from concert.session.utils import ddoc, dstate, pdoc, code_of, abort
@@ -110,6 +110,7 @@ class GUI(QDialog):
         self.motor_inner = None
         self.motor_outer = None
         self.motor_flat = None
+        self.shutter = None
 
 
         # external subgroups to set parameters
@@ -350,7 +351,10 @@ class GUI(QDialog):
         self.concert_scan.acq_setup.flats_before = self.scan_controls_group.ffc_before
         self.concert_scan.acq_setup.flats_after = self.scan_controls_group.ffc_after
         # SET shutter
-        self.concert_scan.ffc_setup.shutter = self.shutter
+        if self.shutter is None:
+            self.concert_scan.ffc_setup.shutter = DummyShutter()
+        else:
+            self.concert_scan.ffc_setup.shutter = self.shutter
         # SET FFC parameters
         if self.scan_controls_group.ffc_before or self.scan_controls_group.ffc_after:
             try:

--- a/ttl_scan.py
+++ b/ttl_scan.py
@@ -76,7 +76,7 @@ def take_ttl_tomo(self):
         else:
             vel = self.motor.calc_vel(
                 self.nsteps, total_time, self.range)
-            if vel > 365 * q.deg / q.sec:
+            if vel.magnitude > 365.0:
                 mesg = "Velocity is too high: {} > 365 deg/s".format(vel)
                 error_message(mesg)
                 LOG.error(mesg)


### PR DESCRIPTION
1. use a `wait_until_stop` for PSO scan. This means waiting until the motion is finished instead of using a sleep. This added a function to the CT motor.
2. Use a dummy shutter if the scan is started with no shutter selected. Program will currently crash if scan is started without a shutter. This allows the scan to continue. There are cases where scans are desired with no shutter control so this replicates the equivalent option in LabVIEW CT program.
3. Improvements were made to `STOP` function that seems to make stopping of CT stage more robust. Changed command to use to `motor.stop()` instead of setting velocity to 0. 